### PR TITLE
Better TS types 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swr-promise",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swr-promise",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "concur-promise": "^1.0.2",

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,9 +1,19 @@
+import type { SwrPromiseCacheNode as CacheNode } from "./index";
+
 type Storage<A, T> = Map<A, T>;
 
 const Storage = Map;
 
-// A: Agreement, T: CacheNode
-export default class Store<A, T> {
+interface Store< A extends any[] = any[], T extends CacheNode = CacheNode> {
+  set(key: A, value: T): void;
+  get(key: A): T | undefined;
+  entries(): IterableIterator<[A, T]>;
+  delete(key: A): boolean;
+  size(): number;
+}
+
+// V: Value of data, A: Agreement, T: CacheNode
+class Store< A extends any[], T extends CacheNode> {
   store: Storage<A, T>;
   constructor() {
     this.store = new Storage<A, T>();
@@ -36,3 +46,5 @@ export default class Store<A, T> {
     return this.store.size;
   }
 }
+
+export default Store


### PR DESCRIPTION
Hi,

This PR tries to improve TS typings.

The main changes:

### unknown over any
`unkown` is prefer over `any` , as any disable type checking. See https://typescript-eslint.io/rules/no-explicit-any/

### Promise input and return type
The return type of the promise is the same as the input type, this way, TS can infer the proper return type of this code:

```ts
const fetch = (): Promise<SomeType>;

const swrFetch = swrPromise(fetch); // properly infer as `(): Promise<SomeType>
```

### Export type declaration

I exported the main types that could be used in several circumstances, like wrapping swr into another function, or overriding default store (in that case, the `Store` interface is helpful)

### Typing the store

I typed the `Store` class as the key is an array, and the data is a `CacheNode`